### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/src/multiprs/corpustools.py
+++ b/src/multiprs/corpustools.py
@@ -175,9 +175,9 @@ class ExmaTokenPOSIterator(object):
         vtier = extract_v_student(tree)
         postier = extract_pos_student(tree)
 
-        if vtier == None:
+        if vtier is None:
             return
-        elif postier == None:
+        elif postier is None:
             return
 
         return file_name, timestamp_token_tupler(vtier), timestamp_token_tupler(postier)
@@ -208,10 +208,10 @@ def make_tier_tuple_list(resourcepath):
         ts_vtier = timestamp_token_tupler(vtier)
         ts_ptier = timestamp_token_tupler(ptier)
 
-        if ts_ptier == None:
+        if ts_ptier is None:
             logging.warning('Skipping file...{} No pos tier parsed'.format(file_name))
             continue
-        if ts_vtier == None:
+        if ts_vtier is None:
             logging.warning('Skipping file...{} No verbal tier parsed'.format(file_name))
             continue
 

--- a/tests/test_trainfile_generation.py
+++ b/tests/test_trainfile_generation.py
@@ -16,9 +16,9 @@ def test_traindata():
     """
     traindata_iterator = corpustools.make_tier_tuple_list(tdata)
     for fname, token, pos in traindata_iterator:
-        assert fname != None
-        assert token != None
-        assert pos != None
+        assert fname is not None
+        assert token is not None
+        assert pos is not None
 
 def test_v_tupels():
     """
@@ -33,8 +33,8 @@ def test_v_tupels():
         for tupel in v_tupels:
             timestamp = tupel[0]
             value = tupel[1]
-            assert timestamp != None
-            assert value != None
+            assert timestamp is not None
+            assert value is not None
 
 
 def test_pos_tupels():
@@ -49,8 +49,8 @@ def test_pos_tupels():
         for tupel in pos_tupels:
             timestamp = tupel[0]
             value = tupel[1]
-            assert timestamp != None
-            assert value != None
+            assert timestamp is not None
+            assert value is not None
 
 
 def test_tokenpos():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fkuhn:multiprs?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:fkuhn:multiprs?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
